### PR TITLE
use warn instead of warning

### DIFF
--- a/lib/global.js
+++ b/lib/global.js
@@ -107,7 +107,7 @@ var globalFn = function(){
 			    },
 			    {
 			    	stream: process.stderr,
-			    	level: "warning"
+			    	level: "warn"
 			    }
 			]
 		});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bluemix-helper-config",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Bluemix Helper for managing config",
   "main": "./lib/index",
   "author": "david_taieb@us.ibm.com",


### PR DESCRIPTION
Logger creation resulted in 

Error: unknown level name: "warning"
    at resolveLevel (D:\P18\node_modules\bunyan\lib\bunyan.js:261:19)
    at Logger.addStream (D:\P18\node_modules\bunyan\lib\bunyan.js:532:19)

Log level string needs to be "warn" https://github.com/trentm/node-bunyan

The log levels in bunyan are as follows. [...]

    "fatal" (60): The service/app is going to stop or become unusable now. An operator should definitely look into this soon.
    "error" (50): Fatal for a particular request, but the service/app continues servicing other requests. An operator should look at this soon(ish).
    "warn" (40): A note on something that should probably be looked at by an operator eventually.
    "info" (30): Detail on regular operation.
    "debug" (20): Anything else, i.e. too verbose to be included in "info" level.
    "trace" (10): Logging from external libraries used by your app or very detailed application logging.
