### PR TITLE
Remove vcap app host dependency

### DIFF
--- a/lib/global.js
+++ b/lib/global.js
@@ -45,7 +45,7 @@ var globalFn = function(){
 	this.appPort = appEnv.port;
 
 	this.getHostName = function(){
-		var url = this.appHost || "http://127.0.0.1";
+		var url = this.appHost || "http://127.0.0.1" + appPort;
 		if ( url.indexOf("://") < 0 ){
 			url = "https://" + this.appHost;
 		}
@@ -53,9 +53,6 @@ var globalFn = function(){
 	};
 	this.getHostUrl = function(){		
 		var url = this.getHostName();
-		if ( this.appPort > 0 ){
-			url += ":" + this.appPort;
-		}
 		return url;
 	};
 	this.gc = function(){

--- a/lib/global.js
+++ b/lib/global.js
@@ -41,8 +41,9 @@ var globalFn = function(){
 	//Call constructor from super class
 	events.EventEmitter.call(this);
 	
-	this.appHost = process.env.VCAP_APP_HOST ? appEnv.urls[0]: null;
-	this.appPort = 0;
+	this.appHost = appEnv.urls[0];
+	this.appPort = appEnv.port;
+
 	this.getHostName = function(){
 		var url = this.appHost || "http://127.0.0.1";
 		if ( url.indexOf("://") < 0 ){

--- a/lib/global.js
+++ b/lib/global.js
@@ -49,6 +49,11 @@ var globalFn = function(){
 		if ( url.indexOf("://") < 0 ){
 			url = "https://" + this.appHost;
 		}
+		// turn localhost into 127.0.0.1 so redirect URLs work after auth
+		// when running locally
+		if( url.indexOf("localhost") ){
+		    url = url.replace("localhost", "127.0.0.1");
+		}
 		return url;
 	};
 	this.getHostUrl = function(){		


### PR DESCRIPTION
These are the changes I needed to make to get the simple data pipe stackoverflow connector to work on both local and remote platforms with the URLs set correctly since the roll out of Diego.  This should also fix #8 